### PR TITLE
Add WWW-Authenticate header to auth middleware

### DIFF
--- a/builtin/middlewares/auth/auth.go
+++ b/builtin/middlewares/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,10 +33,10 @@ type closeable interface {
 type Middleware struct {
 	issuer    string
 	audience  string
+	realm     string
 	resolver  keyResolver
 	jwtConfig jwtConfig
-
-	log *zap.Logger
+	log       *zap.Logger
 }
 
 type jwtConfig struct {
@@ -48,9 +49,20 @@ type jwtConfig struct {
 	jwksRefreshInterval time.Duration
 }
 
+type authChallenge struct {
+	errorCode        string
+	errorDescription string
+}
+
 const (
 	defaultLeeway        = 5 * time.Second
 	authHeaderPartsCount = 2
+
+	defaultRealm     = "kono"
+	bearerAuthScheme = "Bearer"
+
+	authErrorInvalidRequest = "invalid_request"
+	authErrorInvalidToken   = "invalid_token"
 )
 
 func NewMiddleware() sdk.Middleware {
@@ -79,6 +91,20 @@ func (m *Middleware) Init(config map[string]interface{}) error {
 
 	m.issuer = issuer
 	m.audience = audience
+	m.realm = defaultRealm
+
+	rawRealm, hasRealm := config["realm"]
+	if hasRealm {
+		realm, isString := rawRealm.(string)
+		if !isString {
+			return errors.New("realm must be a string")
+		}
+
+		realm = strings.TrimSpace(realm)
+		if realm != "" {
+			m.realm = realm
+		}
+	}
 
 	cfg := jwtConfig{alg: alg}
 
@@ -125,13 +151,16 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
-			unauthorized(w)
+			m.unauthorized(w, authChallenge{})
 			return
 		}
 
 		parts := strings.SplitN(authHeader, " ", authHeaderPartsCount)
 		if len(parts) != authHeaderPartsCount || !strings.EqualFold(parts[0], "Bearer") {
-			unauthorized(w)
+			m.unauthorized(w, authChallenge{
+				errorCode:        authErrorInvalidRequest,
+				errorDescription: "invalid authorization header",
+			})
 			return
 		}
 
@@ -143,18 +172,27 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 			jwt.WithLeeway(defaultLeeway),
 		)
 		if err != nil || !token.Valid {
-			unauthorized(w)
+			m.unauthorized(w, authChallenge{
+				errorCode:        authErrorInvalidToken,
+				errorDescription: "invalid or expired token",
+			})
 			return
 		}
 
 		claims, ok := token.Claims.(*jwt.MapClaims)
 		if !ok {
-			unauthorized(w)
+			m.unauthorized(w, authChallenge{
+				errorCode:        authErrorInvalidToken,
+				errorDescription: "invalid token claims",
+			})
 			return
 		}
 
 		if err = m.validateClaims(claims); err != nil {
-			unauthorized(w)
+			m.unauthorized(w, authChallenge{
+				errorCode:        authErrorInvalidToken,
+				errorDescription: "invalid token claims",
+			})
 			return
 		}
 
@@ -229,10 +267,37 @@ func (m *Middleware) newJWKSResolver(cfg jwtConfig) (keyResolver, error) {
 	return r, nil
 }
 
-func unauthorized(w http.ResponseWriter) {
+func (m *Middleware) unauthorized(w http.ResponseWriter, c authChallenge) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(
+		"WWW-Authenticate",
+		buildWWWAuthenticateHeader(m.realm, c.errorCode, c.errorDescription),
+	)
+
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"errors":[{"code":"UNAUTHORIZED"}]}`))
+}
+
+func buildWWWAuthenticateHeader(realm, errorCode, errorDescription string) string {
+	realm = strings.TrimSpace(realm)
+
+	if realm == "" {
+		realm = defaultRealm
+	}
+
+	header := bearerAuthScheme + " realm=" + strconv.Quote(realm)
+
+	if errorCode == "" {
+		return header
+	}
+
+	header += ", error=" + strconv.Quote(errorCode)
+
+	if errorDescription != "" {
+		header += ", error_description=" + strconv.Quote(errorDescription)
+	}
+
+	return header
 }
 
 func parseDuration(config map[string]interface{}, key string, fallback time.Duration) time.Duration {

--- a/builtin/middlewares/auth/auth_test.go
+++ b/builtin/middlewares/auth/auth_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Auth", func() {
 			m = &Middleware{
 				issuer:   "test-issuer",
 				audience: "test-aud",
+				realm:    defaultRealm,
 				resolver: &hmacResolver{HMACSecret: secret},
 				jwtConfig: jwtConfig{
 					alg:        "HS256",
@@ -59,6 +60,7 @@ var _ = Describe("Auth", func() {
 				h.ServeHTTP(rec, req)
 
 				Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+				Expect(rec.Header().Get("WWW-Authenticate")).To(Equal(`Bearer realm="kono"`))
 			})
 		})
 
@@ -76,6 +78,9 @@ var _ = Describe("Auth", func() {
 				h.ServeHTTP(rec, req)
 
 				Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+				Expect(rec.Header().Get("WWW-Authenticate")).To(Equal(
+					`Bearer realm="kono", error="invalid_token", error_description="invalid or expired token"`,
+				))
 			})
 		})
 
@@ -96,6 +101,9 @@ var _ = Describe("Auth", func() {
 				h.ServeHTTP(rec, req)
 
 				Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+				Expect(rec.Header().Get("WWW-Authenticate")).To(Equal(
+					`Bearer realm="kono", error="invalid_token", error_description="invalid or expired token"`,
+				))
 			})
 		})
 
@@ -121,9 +129,77 @@ var _ = Describe("Auth", func() {
 				h.ServeHTTP(rec, req)
 
 				Expect(rec.Code).To(Equal(http.StatusOK))
+				Expect(rec.Header().Get("WWW-Authenticate")).To(BeEmpty())
 				Expect(gotClaims).ToNot(BeNil())
 				Expect(gotClaims.GetIssuer()).To(Equal("test-issuer"))
 				Expect(gotClaims.GetAudience()).To(ContainElement("test-aud"))
+
+			})
+		})
+		Context("malformed authorization header", func() {
+			It("returns invalid_request challenge", func() {
+				h := m.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte("ok"))
+				}))
+
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("Authorization", "Basic abc123")
+
+				rec := httptest.NewRecorder()
+
+				h.ServeHTTP(rec, req)
+
+				Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+				Expect(rec.Header().Get("WWW-Authenticate")).To(Equal(
+					`Bearer realm="kono", error="invalid_request", error_description="invalid authorization header"`,
+				))
+			})
+		})
+		Describe("buildWWWAuthenticateHeader", func() {
+			It("builds a realm-only Bearer challenge", func() {
+				Expect(buildWWWAuthenticateHeader("kono", "", "")).To(Equal(`Bearer realm="kono"`))
+			})
+
+			It("builds an invalid_token Bearer challenge", func() {
+				Expect(buildWWWAuthenticateHeader("kono", authErrorInvalidToken, "invalid or expired token")).To(Equal(
+					`Bearer realm="kono", error="invalid_token", error_description="invalid or expired token"`,
+				))
+			})
+
+			It("uses the default realm when realm is empty", func() {
+				Expect(buildWWWAuthenticateHeader("", authErrorInvalidRequest, "invalid authorization header")).To(Equal(
+					`Bearer realm="kono", error="invalid_request", error_description="invalid authorization header"`,
+				))
+			})
+		})
+		Describe("Init", func() {
+			It("uses a custom realm from config", func() {
+				middleware := &Middleware{}
+
+				err := middleware.Init(map[string]interface{}{
+					"issuer":      "test-issuer",
+					"audience":    "test-aud",
+					"alg":         "HS256",
+					"hmac_secret": "c2VjcmV0",
+					"realm":       "custom-realm",
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(middleware.realm).To(Equal("custom-realm"))
+			})
+
+			It("uses the default realm when none is configured", func() {
+				middleware := &Middleware{}
+
+				err := middleware.Init(map[string]interface{}{
+					"issuer":      "test-issuer",
+					"audience":    "test-aud",
+					"alg":         "HS256",
+					"hmac_secret": "c2VjcmV0",
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(middleware.realm).To(Equal(defaultRealm))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

Adds the `WWW-Authenticate` header to 401 responses returned by the auth middleware, following the Bearer authentication challenge format.

The middleware now:

- sets `WWW-Authenticate` on every unauthorized response
- supports a configurable `realm`
- defaults the realm to `"kono"`
- returns `invalid_request` for malformed Authorization headers
- returns `invalid_token` for invalid, expired, or invalid-claims tokens
- avoids exposing sensitive token or claim details in `error_description`

## Tests

- Added unit coverage for `WWW-Authenticate` header generation
- Added middleware tests for missing Authorization header
- Added middleware tests for invalid Authorization header
- Added middleware tests for invalid token
- Added middleware tests for custom/default realm behavior
- Confirmed valid requests do not include `WWW-Authenticate`

```
bash
go test ./builtin/middlewares/auth -v
go test ./...
````